### PR TITLE
change from bme280.init() to bme280.setup()

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ To run the exporter you need to have a NodeMCU [firmware](https://nodemcu.readth
 - uart
 - wifi
 - bme280
+- i2c
 
 For building I used the online [build service](https://nodemcu-build.com/) by Marcel Stör.  
 For flashing I used [esptool](https://github.com/espressif/esptool).

--- a/application.lua
+++ b/application.lua
@@ -37,7 +37,8 @@ function response()
   return response
 end
 
-bme280.init(sda, scl)
+i2c.setup(0, sda, scl, i2c.SLOW) -- call i2c.setup() only once
+bme280.setup()
 
 srv = net.createServer(net.TCP, 20) -- 20s timeout
 


### PR DESCRIPTION
this prevents further deprecation of bme280.init():
```
Warning, deprecated API! bme280.init() is replaced by bme280.setup(). It will be removed in the next version. See documentation for details.
```